### PR TITLE
Changed the -q option to now specific the minimum buffer size

### DIFF
--- a/openob/rtp/tx.py
+++ b/openob/rtp/tx.py
@@ -31,7 +31,8 @@ class RTPTransmitter:
       self.source = gst.element_factory_make("pulsesrc")
     if queuesize != 0:
 	self.queue = gst.element_factory_make("queue")
-	self.queue.set_property("max-size-time", queuesize*1000)
+	self.queue.set_property("min-threshold-time", queuesize*1000)
+	self.queue.set_property("max-size-time", queuesize*1000*2)
 	self.pipeline.add(self.queue)
     # Audio conversion and resampling
     self.audioconvert = gst.element_factory_make("audioconvert")


### PR DESCRIPTION
rather than maximum.  Maximum queue size is now twice the minimum size.

As per "Re: [openob-users] clicks on audio" - setting the maximum doesn't make much sense as the queue will allow reads before any samples are in the queue (i.e. the min-size-time param is 0 by default).

https://github.com/JamesHarrison/openob/issues/19
