### PR TITLE
Bugfix for PCM links (unlinkable pads)

### DIFF
--- a/openob/rtp/rx.py
+++ b/openob/rtp/rx.py
@@ -34,9 +34,9 @@ class RTPReceiver(object):
             self.sink.set_property('name', self.audio_interface.jack_name)
             self.sink.set_property('client-name', self.audio_interface.jack_name)
 
-        # Audio conversion and resampling
-        self.audioconvert = gst.element_factory_make("audioconvert")
+        # Audio resampling and conversion
         self.audioresample = gst.element_factory_make("audioresample")
+        self.audioconvert = gst.element_factory_make("audioconvert")
         self.audioresample.set_property('quality', 6)
 
         # Decoding and depayloading
@@ -78,16 +78,16 @@ class RTPReceiver(object):
 
         # And now we've got it all set up we need to add the elements
         self.pipeline.add(
-            self.audioresample, self.audioconvert, self.sink,
+            self.audioconvert, self.audioresample, self.sink,
             self.level, self.depayloader, self.rtpbin, self.udpsrc_rtpin)
         if self.link_config.encoding != 'pcm':
             self.pipeline.add(self.decoder)
             gst.element_link_many(
-                self.depayloader, self.decoder, self.audioresample)
+                self.depayloader, self.decoder, self.audioconvert)
         else:
-            gst.element_link_many(self.depayloader, self.audioresample)
+            gst.element_link_many(self.depayloader, self.audioconvert)
         gst.element_link_many(
-            self.audioresample, self.audioconvert, self.level,
+            self.audioconvert, self.audioresample, self.level,
             self.sink)
         self.logger.debug(self.sink)
         # Now the RTP pads

--- a/openob/rtp/tx.py
+++ b/openob/rtp/tx.py
@@ -36,9 +36,9 @@ class RTPTransmitter(object):
             self.source.set_property('buffer-time', 50000)
             self.source.set_property('name', self.audio_interface.jack_name)
             self.source.set_property('client-name', self.audio_interface.jack_name)
-        # Audio conversion and resampling
-        self.audioconvert = gst.element_factory_make("audioconvert")
+        # Audio resampling and conversion
         self.audioresample = gst.element_factory_make("audioresample")
+        self.audioconvert = gst.element_factory_make("audioconvert")
         self.audioresample.set_property('quality', 6)  # SRC
 
         # Encoding and payloading
@@ -79,7 +79,7 @@ class RTPTransmitter(object):
 
         # Add to the pipeline
         self.pipeline.add(
-            self.source, self.capsfilter, self.audioconvert, self.audioresample,
+            self.source, self.capsfilter, self.audioresample, self.audioconvert,
             self.payloader, self.udpsink_rtpout, self.rtpbin,
             self.level)
 
@@ -103,14 +103,14 @@ class RTPTransmitter(object):
 
         # Then continue linking the pipeline together
         gst.element_link_many(
-            self.source, self.capsfilter, self.level, self.audioconvert, self.audioresample)
+            self.source, self.capsfilter, self.level, self.audioresample, self.audioconvert)
 
         # Now we get to link this up to our encoder/payloader
         if self.link_config.encoding != 'pcm':
             gst.element_link_many(
-                self.audioresample, self.encoder, self.payloader)
+                self.audioconvert, self.encoder, self.payloader)
         else:
-            gst.element_link_many(self.audioresample, self.payloader)
+            gst.element_link_many(self.audioconvert, self.payloader)
 
         # And now the RTP bits
         self.payloader.link_pads('src', self.rtpbin, 'send_rtp_sink_0')


### PR DESCRIPTION
Audioresample refuses to connect to rtpL16pay/depay under certain caps, so audioconvert is placed last in the pipeline before RTP payloading instead.  This should ensure that the RTP elements get exactly what they are compatible with.