### PR TITLE
Add a redis ping on making a connection to ensure we can talk to it

### DIFF
--- a/openob/link_config.py
+++ b/openob/link_config.py
@@ -28,6 +28,7 @@ class LinkConfig(object):
         while True:
             try:
                 self.redis = redis.StrictRedis(host=self.redis_host, charset="utf-8", decode_responses=True)
+                self.redis.ping()
                 break
             except Exception as e:
                 self.logger.error(


### PR DESCRIPTION
Under my tests, we never reached the exception because the connection was made successfully, but never 'checked'. Without this fix, I'd quickly get the following exception on trying to carry out the first action with Redis:

```
Traceback (most recent call last):
  File "/usr/local/bin/openob", line 81, in <module>
    link_config.set_from_argparse(opts)
  File "/usr/local/lib/python2.7/dist-packages/openob/link_config.py", line 83, in set_from_argparse
    self.set("name", opts.link_name)
  File "/usr/local/lib/python2.7/dist-packages/openob/link_config.py", line 51, in set
    self.redis.set(scoped_key, value)
  File "/usr/lib/python2.7/dist-packages/redis/client.py", line 1072, in set
    return self.execute_command('SET', *pieces)
  File "/usr/lib/python2.7/dist-packages/redis/client.py", line 578, in execute_command
    connection.send_command(*args)
  File "/usr/lib/python2.7/dist-packages/redis/connection.py", line 563, in send_command
    self.send_packed_command(self.pack_command(*args))
  File "/usr/lib/python2.7/dist-packages/redis/connection.py", line 538, in send_packed_command
    self.connect()
  File "/usr/lib/python2.7/dist-packages/redis/connection.py", line 442, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error 113 connecting to 192.168.10.1:6379. No route to host.
```